### PR TITLE
Add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# alltuner.com
+
+The marketing website for [All Tuner Labs](https://alltuner.com). Hugo static site with Tailwind CSS v4, English / Catalan / Spanish content.
+
+## Stack
+
+| Layer | Tool |
+|---|---|
+| Static site generator | [Hugo](https://gohugo.io) |
+| CSS | [Tailwind CSS v4](https://tailwindcss.com) |
+| JS bundler | [bun](https://bun.sh) |
+| Languages | English, Catalan, Spanish |
+
+## Develop
+
+```bash
+bun install                # install JS dependencies
+bun run dev                # build assets + run hugo serve with hot reload
+```
+
+Visit `http://localhost:1313/`.
+
+Other useful targets:
+
+```bash
+bun run build              # production build (assets + hugo)
+bun run css:watch          # rebuild Tailwind CSS on change
+bun run js:watch           # rebuild theme JS on change
+bun run clean              # remove the public/ output
+```
+
+## Layout
+
+```
+alltuner.com/
+├── content/               # Markdown content (per-language subdirs under content/ca, content/es)
+├── css/                   # Tailwind input
+├── data/                  # Hugo data files
+├── static/                # Static assets served as-is
+├── themes/alltuner-theme/ # Hugo theme (templates, JS, partials)
+└── hugo.toml              # Hugo config
+```
+
+See [`AGENTS.md`](AGENTS.md) for the conventions used by the theme and the editorial flow.


### PR DESCRIPTION
## Summary

This repo had no README. Adds a minimal one following the aggregator variant of the canonical brand template (`alltuner/brand:readme-template/README.minimal.md`):

- Tech stack table.
- `bun run dev` quick-start.
- Layout overview.

The website itself is a Hugo + Tailwind v4 static site, multilingual (en / ca / es).

## Follow-up

This repo has **no LICENSE file** and no license declared on GitHub. Marketing-site code often stays proprietary, so the README intentionally omits a `## License` section rather than guessing. Decide separately whether to add a LICENSE file.

## Test plan

- [ ] Render on github.com and verify the layout block reads cleanly.
- [ ] Confirm `bun run dev` actually still serves on `:1313` (the standard Hugo port).

🤖 Generated with [Claude Code](https://claude.com/claude-code)