### PR TITLE
chore: remove archived projectuner from minor projects

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -229,8 +229,3 @@ link = "https://github.com/alltuner/switchyard"
 name = "skills"
 description = "Agent skills published by alltuner — install via skills.sh."
 link = "https://github.com/alltuner/skills"
-
-[[params.minor_projects]]
-name = "projectuner"
-description = "Copier template for git bare repo + worktree projects."
-link = "https://github.com/alltuner/projectuner"


### PR DESCRIPTION
## Summary
- Removes \`projectuner\` from the minor projects list — the repo is archived on GitHub.

## Test plan
- [ ] \`/projects\` page no longer lists projectuner under minor projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)