### PR TITLE
refactor: sort projects alphabetically by name in template

### DIFF
--- a/themes/alltuner-theme/layouts/projects/list.html
+++ b/themes/alltuner-theme/layouts/projects/list.html
@@ -33,7 +33,7 @@
 </header>
 
 <main id="main" role="main" class="w-full max-w-3xl mx-auto px-6 md:px-8 pb-16 md:pb-24">
-  {{- $projects := .Site.Params.projects -}}
+  {{- $projects := sort .Site.Params.projects "name" -}}
   {{- $lang := .Language.Lang -}}
 
   <div class="space-y-0 animate-fade-up" style="animation-delay: 0.5s">
@@ -71,7 +71,7 @@
   </div>
 
   <!-- Minor projects -->
-  {{ with .Site.Params.minor_projects }}
+  {{ with sort .Site.Params.minor_projects "name" }}
   <div class="mt-8 md:mt-10 flex justify-center" aria-hidden="true">
     <div class="h-px w-24 bg-gradient-to-r from-transparent via-wine/50 to-transparent"></div>
   </div>


### PR DESCRIPTION
## Summary
- Sort \`params.projects\` and \`params.minor_projects\` alphabetically by \`name\` directly in the projects layout, using Hugo's \`sort\` function.
- No metadata changes — \`hugo.toml\` ordering is preserved as a free-form editorial source.

## Test plan
- [ ] \`/projects\` lists majors as: Castuner, DevTuner, Factory Floor, Gitcabin, Nameplate, Radar de la Música, Shiftuner, Uns minuts i a clapar, Vacant, VibeTuner.
- [ ] Minor list: cookietuner, mise-completions-sync, silicate, skills, switchyard, vaultuner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)